### PR TITLE
Login error handling

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1,6 +1,5 @@
 {
     "@@locale": "en",
-
     "continueWatching": "Continue Watching",
     "recentlyAddedMovies": "Recently Added Movies",
     "recentlyAddedShows": "Recently Added Shows",
@@ -95,6 +94,11 @@
     "login": "Login",
     "username": "Username",
     "password": "Password",
+    "emptyAddress": "Empty Server Address",
+    "emptyUsername": "Empty Username",
+    "emptyPassword": "Empty Password",
+    "emptyFields": "Please fill out the following fields",
+    "errorConnectingToServer": "Error connecting to server",
     "webDemoNote": "This is a demo version of Jellyflix. To use it, you can use the following credentials: \n\nServer Address: https://demo.jellyfin.org/stable \nUser Name: demo \nand empty password \n\n",
     "quality": "Quality",
     "audio": "Audio",
@@ -120,7 +124,7 @@
           }
         }
       },
-    "minutes": "{count} min",  
+    "minutes": "{count} min",
     "@minutes": {
         "placeholders": {
             "count": {
@@ -181,5 +185,5 @@
     "info": "Info",
     "showPrimaryForEpisodes": "Show primary image instead of series poster in Continue Watching",
     "appName": "Jellyflix"
-    
+
 }

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -1,12 +1,13 @@
+import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:go_router/go_router.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:jellyflix/models/screen_paths.dart';
 import 'package:jellyflix/models/user.dart';
 import 'package:jellyflix/providers/auth_provider.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter_hooks/flutter_hooks.dart';
-import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 class LoginScreen extends HookConsumerWidget {
   const LoginScreen({super.key});
@@ -16,6 +17,7 @@ class LoginScreen extends HookConsumerWidget {
     final userName = useTextEditingController();
     final password = useTextEditingController();
     final serverAddress = useTextEditingController();
+
     return Scaffold(
       appBar: AppBar(),
       body: Center(
@@ -39,9 +41,10 @@ class LoginScreen extends HookConsumerWidget {
                   child: TextField(
                     controller: serverAddress,
                     decoration: InputDecoration(
-                        border: const OutlineInputBorder(),
-                        labelText: AppLocalizations.of(context)!.serverAddress,
-                        hintText: 'http://'),
+                      border: const OutlineInputBorder(),
+                      labelText: AppLocalizations.of(context)!.serverAddress,
+                      hintText: 'http://',
+                    ),
                   ),
                 ),
                 Padding(
@@ -73,17 +76,54 @@ class LoginScreen extends HookConsumerWidget {
                     child: FilledButton(
                       onPressed: () async {
                         try {
+                          final missingFields = formatMissingFields(
+                            context,
+                            userName.text,
+                            password.text,
+                            serverAddress.text,
+                          );
+                          if (missingFields.isNotEmpty) {
+                            await showInfoDialog(
+                              context,
+                              Text(
+                                AppLocalizations.of(context)!.emptyFields,
+                              ),
+                              content: Text(missingFields),
+                            );
+                            return;
+                          }
+
                           User user = User(
-                              name: userName.text,
-                              password: password.text,
-                              serverAdress: serverAddress.text);
+                            name: userName.text,
+                            password: password.text,
+                            serverAdress: serverAddress.text,
+                          );
                           await ref.read(authProvider).login(user);
                           if (context.mounted) {
                             context.go(ScreenPaths.home);
                           }
+                        } on DioException catch (e) {
+                          if (!context.mounted) return;
+                          await showInfoDialog(
+                            context,
+                            Text(
+                              AppLocalizations.of(context)!
+                                  .errorConnectingToServer,
+                            ),
+                            content: e.response?.statusCode == null
+                                ? Text(e.toString())
+                                : Text(formatHttpErrorCode(e.response)),
+                          );
+                          return;
                         } catch (e) {
-                          // TODO: show error message to user
-                          //print(e);
+                          if (!context.mounted) return;
+                          await showInfoDialog(
+                            context,
+                            Text(AppLocalizations.of(context)!
+                                .errorConnectingToServer),
+                            content: Text(e.toString()),
+                          );
+                          return;
                         }
                       },
                       child: Text(AppLocalizations.of(context)!.login),
@@ -99,5 +139,64 @@ class LoginScreen extends HookConsumerWidget {
         ),
       )),
     );
+  }
+
+  Future<void> showInfoDialog(
+    BuildContext context,
+    Widget title, {
+    Widget? content,
+  }) async {
+    await showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: title,
+        content: content,
+        actions: [
+          ElevatedButton(
+            onPressed: () {
+              Navigator.pop(context);
+            },
+            child: const Text('Ok'),
+          )
+        ],
+      ),
+    );
+  }
+
+  String formatMissingFields(BuildContext context, String username,
+      String password, String serverAddress) {
+    var missingFields = '';
+    if (username.isEmpty) {
+      missingFields += '${AppLocalizations.of(context)!.emptyUsername}\n\n';
+    }
+    if (password.isEmpty) {
+      missingFields += '${AppLocalizations.of(context)!.emptyPassword}\n\n';
+    }
+    if (serverAddress.isEmpty) {
+      missingFields += '${AppLocalizations.of(context)!.emptyAddress}\n\n';
+    }
+
+    return missingFields;
+  }
+
+  String formatHttpErrorCode(Response? resp) {
+    var message = '';
+    switch (resp!.statusCode) {
+      case 400:
+        message =
+            'Something went wrong while making the request, this is probably a issue within Jellyflix, please open a github issue';
+      case 401:
+        message = 'Your username or password may be incorrect';
+      case 403:
+        message =
+            'The Server has probably banned this IP, please contact your admin to resolve this issue';
+      default:
+        message = '';
+    }
+
+    return '$message\n\n'
+            'Http Code: ${resp.statusCode ?? 'Unknown'}\n\n'
+            'Http Response: ${resp.statusMessage ?? 'Unknown'}\n\n'
+        .trim();
   }
 }

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -10,6 +10,7 @@ class AuthService {
   final DatabaseService _databaseService;
 
   final StreamController<bool> _authStateStream = StreamController();
+
   Stream<bool> get authStateChange => _authStateStream.stream;
 
   Future<bool> get isAuthenticated => _authStateStream.stream.last;
@@ -60,7 +61,8 @@ class AuthService {
           user.serverAdress!, user.name!, user.password!);
     } catch (e) {
       if (user.serverAdress!.split(":").last != "8096" &&
-          user.serverAdress!.split(":").length == 2) {
+          user.serverAdress!.split(":").length == 2 &&
+          user.serverAdress!.split(":").first == 'http') {
         user.serverAdress = "${user.serverAdress}:8096";
         user = await _apiService.login(
             user.serverAdress!, user.name!, user.password!);


### PR DESCRIPTION
## Changes

Added support for autofill, so password managers can autofill credentials.

## Ui changes

Default error handling UI.

![default](https://github.com/user-attachments/assets/692ddcdd-ce35-4635-9100-952a9b367d40)

Specific error messages for certain HTTP codes. If a response does not match a specific code, it defaults to the normal UI.

![err](https://github.com/user-attachments/assets/20b2bdb1-5d61-4b2a-b899-45e7ebe7cbce)

Added a check for empty inputs.

![missing](https://github.com/user-attachments/assets/ca5f4e71-6be7-4c60-a398-64598ed038cc)

## Bug fix

There was also a bug in the auth logic

The if condition adds a port regardless of the protocol, which will cause a tls mismatch error if we put https address and the error handler adds the port.

relevant line

```dart
if (user.serverAdress!.split(":").last != "8096" &&
          user.serverAdress!.split(":").length == 2 
```

adds a HTTP check

```dart
if (user.serverAdress!.split(":").last != "8096" &&
          user.serverAdress!.split(":").length == 2 &&
          user.serverAdress!.split(":").first == 'http')
```