### PR TITLE
feat: added autocomplete options to url input

### DIFF
--- a/lib/components/custom_autocomplete_options.dart
+++ b/lib/components/custom_autocomplete_options.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
+
+class CustomAutocompleteOptions<T extends Object> extends StatelessWidget {
+  const CustomAutocompleteOptions({
+    super.key,
+    required this.displayStringForOption,
+    required this.onSelected,
+    required this.openDirection,
+    required this.options,
+    required this.maxOptionsHeight,
+    required this.maxOptionsWidth,
+  });
+
+  final AutocompleteOptionToString<T> displayStringForOption;
+
+  final AutocompleteOnSelected<T> onSelected;
+  final OptionsViewOpenDirection openDirection;
+
+  final Iterable<T> options;
+  final double maxOptionsHeight;
+  final double maxOptionsWidth;
+
+  @override
+  Widget build(BuildContext context) {
+    final AlignmentDirectional optionsAlignment = switch (openDirection) {
+      OptionsViewOpenDirection.up => AlignmentDirectional.bottomStart,
+      OptionsViewOpenDirection.down => AlignmentDirectional.topStart,
+    };
+    return Align(
+      alignment: optionsAlignment,
+      child: Material(
+        elevation: 4.0,
+        child: ConstrainedBox(
+          constraints: BoxConstraints(
+            maxHeight: maxOptionsHeight,
+            maxWidth: maxOptionsWidth,
+          ),
+          child: ListView.builder(
+            padding: EdgeInsets.zero,
+            shrinkWrap: true,
+            itemCount: options.length,
+            itemBuilder: (BuildContext context, int index) {
+              final T option = options.elementAt(index);
+              return InkWell(
+                onTap: () {
+                  onSelected(option);
+                },
+                child: Builder(builder: (BuildContext context) {
+                  final bool highlight =
+                      AutocompleteHighlightedOption.of(context) == index;
+                  if (highlight) {
+                    SchedulerBinding.instance.addPostFrameCallback(
+                        (Duration timeStamp) {
+                      Scrollable.ensureVisible(context, alignment: 0.5);
+                    }, debugLabel: 'AutocompleteOptions.ensureVisible');
+                  }
+                  return Container(
+                    color: highlight ? Theme.of(context).focusColor : null,
+                    padding: const EdgeInsets.all(16.0),
+                    child: Text(displayStringForOption(option)),
+                  );
+                }),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -1,11 +1,13 @@
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:jellyflix/components/custom_autocomplete_options.dart';
 import 'package:jellyflix/models/screen_paths.dart';
 import 'package:jellyflix/models/user.dart';
 import 'package:jellyflix/providers/auth_provider.dart';
@@ -56,15 +58,7 @@ class LoginScreen extends HookConsumerWidget {
                         const SizedBox(height: 20),
                         Padding(
                           padding: const EdgeInsets.symmetric(vertical: 10.0),
-                          child: TextField(
-                            controller: serverAddress,
-                            decoration: InputDecoration(
-                              border: const OutlineInputBorder(),
-                              labelText:
-                                  AppLocalizations.of(context)!.serverAddress,
-                              hintText: 'http://',
-                            ),
-                          ),
+                          child: UrlFieldInput(serverAddress: serverAddress),
                         ),
                         Padding(
                           padding: const EdgeInsets.symmetric(vertical: 10.0),
@@ -264,5 +258,69 @@ class LoginScreen extends HookConsumerWidget {
             'Http Code: ${resp.statusCode ?? 'Unknown'}\n\n'
             'Http Response: ${resp.statusMessage ?? 'Unknown'}\n\n'
         .trim();
+  }
+}
+
+class UrlFieldInput extends ConsumerWidget {
+  const UrlFieldInput({super.key, required this.serverAddress});
+
+  final TextEditingController serverAddress;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final savedAddress = ref.watch(allProfilesProvider);
+
+    // needed to get width of the url text filed
+    // so we can assign that to the autocomplete width
+    final urlTextFieldKey = GlobalKey();
+
+    return RawAutocomplete<String>(
+      focusNode: FocusNode(),
+      textEditingController: serverAddress,
+      optionsBuilder: (TextEditingValue textEditingValue) {
+        final result = savedAddress.valueOrNull
+            ?.where((element) => element.serverAdress!
+                .toLowerCase()
+                .contains(textEditingValue.text))
+            .map((e) => e.serverAdress!);
+        return result == null || result.isEmpty
+            ? ['http://', 'https://']
+            : result;
+      },
+      onSelected: (option) => serverAddress.text = option,
+      optionsViewOpenDirection: OptionsViewOpenDirection.down,
+      fieldViewBuilder: (context, controller, focusNode, _) {
+        return TextField(
+          key: urlTextFieldKey,
+          focusNode: focusNode,
+          controller: controller,
+          decoration: InputDecoration(
+            border: const OutlineInputBorder(),
+            labelText: AppLocalizations.of(context)!.serverAddress,
+            hintText: 'http://',
+          ),
+        );
+      },
+      optionsViewBuilder: (
+        BuildContext context,
+        void Function(String) onSelected,
+        Iterable<String> options,
+      ) {
+        RenderBox? renderBox;
+        if (urlTextFieldKey.currentContext?.findRenderObject() != null) {
+          renderBox =
+              urlTextFieldKey.currentContext!.findRenderObject() as RenderBox;
+        }
+
+        return CustomAutocompleteOptions(
+          displayStringForOption: RawAutocomplete.defaultStringForOption,
+          onSelected: onSelected,
+          options: options,
+          openDirection: OptionsViewOpenDirection.down,
+          maxOptionsHeight: 100,
+          maxOptionsWidth: renderBox?.size.width ?? 300,
+        );
+      },
+    );
   }
 }


### PR DESCRIPTION
Implemented #127, had to make a custom autocomplete because the default one does not accept a controller and defaults to maxwidth.

If no addresses are found:

![image](https://github.com/user-attachments/assets/0b57d375-525b-4486-9379-b05e9308f505)

If previous address are present:

![image](https://github.com/user-attachments/assets/ec91e71b-2b65-4116-bf09-56614b7cb37d)
